### PR TITLE
Create organization_types.sql

### DIFF
--- a/database/scripts/organization_types.sql
+++ b/database/scripts/organization_types.sql
@@ -1,0 +1,3 @@
+INSERT INTO `organization_types` (`id`, `title`, `created_at`, `updated_at`, `status`, `deleted_at`) VALUES
+(1, 'non-government', NULL, NULL, 1, NULL),
+(2, 'government', NULL, NULL, 1, NULL);


### PR DESCRIPTION
Dummy data for Organization types. In the database I didn't find any restrictions for adding values to the organization type id without having a referencing value in the organization_types table yet. but since it is the proper method to fill organization types table first adding some dummy data